### PR TITLE
Fix order of generateSignature()

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,3 +226,10 @@ try {
 }
 ```
 
+#### Testing for package developers
+
+If you implement a new feature, write corresponding unit tests that will uncover bugs, e.g. if you write a function that generates a signature, write a unit test that validates the signature.
+Once you made changes - be sure to run the unit tests. 
+
+To run unit `phpunit --bootstrap vendor/autoload.php tests/`.
+

--- a/README.md
+++ b/README.md
@@ -226,10 +226,16 @@ try {
 }
 ```
 
-#### Testing for package developers
+## Testing for package developers
 
 If you implement a new feature, write corresponding unit tests that will uncover bugs, e.g. if you write a function that generates a signature, write a unit test that validates the signature.
-Once you made changes - be sure to run the unit tests. 
+Once you made changes - be sure to run all the unit tests. 
 
-To run unit `phpunit --bootstrap vendor/autoload.php tests/`.
+In the root directory, first run (only once)
+
+```composer i```
+
+and to run tests, use 
+
+```phpunit --bootstrap vendor/autoload.php tests/```.
 

--- a/lib/Auth.php
+++ b/lib/Auth.php
@@ -70,7 +70,7 @@ class Auth
         // Create parameter string
         $pfOutput = '';
         foreach ($fields as $attribute) {
-            if (!empty($data[$attribute])) {
+            if (isset($data[$attribute])) {
                 $pfOutput .= $attribute .'='. urlencode(trim($data[$attribute])) .'&';
             }
         }

--- a/lib/Auth.php
+++ b/lib/Auth.php
@@ -57,28 +57,21 @@ class Auth
             'name_first', 'name_last', 'email_address', 'cell_number', 'm_payment_id', 'amount', 'item_name',
             'item_description', 'custom_int1', 'custom_int2', 'custom_int3', 'custom_int4', 'custom_int5',
             'custom_str1', 'custom_str2', 'custom_str3', 'custom_str4', 'custom_str5', 'email_confirmation',
-            'confirmation_address', 'currency', 'payment_method', 'subscription_type', 'passphrase',
+            'confirmation_address', 'currency', 'payment_method', 'subscription_type', 
             'billing_date', 'recurring_amount', 'frequency', 'cycles', 'subscription_notify_email',
-            'subscription_notify_webhook', 'subscription_notify_buyer'];
-
-        $sortAttributes = array_filter($data, function ($key) use ($fields) {
-            return in_array($key, $fields);
-        }, ARRAY_FILTER_USE_KEY);
-
-        if($passPhrase !== null && $passPhrase !== '') {
-            $sortAttributes['passphrase'] = urlencode(trim($passPhrase));
-        }
+            'subscription_notify_webhook', 'subscription_notify_buyer', 'passphrase'];
 
         // Some functionality requires the passphrase to be set
         if (isset($data['subscription_type']) && ($passPhrase === null || $passPhrase === '')) {
             throw new InvalidRequestException('Subscriptions require a passphrase to be set', 400);
         }
-
+        $data['passphrase'] = $passPhrase;
+        
         // Create parameter string
         $pfOutput = '';
-        foreach($sortAttributes as $attribute => $value) {
-            if(!empty($value)) {
-                $pfOutput .= $attribute .'='. urlencode(trim($value)) .'&';
+        foreach ($fields as $attribute) {
+            if (!empty($data[$attribute])) {
+                $pfOutput .= $attribute .'='. urlencode(trim($data[$attribute])) .'&';
             }
         }
         // Remove last ampersand

--- a/tests/unit/AuthTest.php
+++ b/tests/unit/AuthTest.php
@@ -18,18 +18,33 @@ class AuthTest extends TestCase
     public function testGenerateSignatureOrdering()
     {
         $data = array(
-            'email_address' => 'test@test.com',
-            'merchant_key' => '46f0cd694581a',
-            'notify_url' => 'http://www.example.com/notify_url',
-            'name_first' => 'First',
-            'name_last' => 'Last',
-            'cancel_url' => 'http://www.example.com/cancel_url',
-            'return_url' => 'http://www.example.com/return_url',
-            'merchant_id' => '10000100',
+            'merchant_id'          => 10028084,
+            'merchant_key'         => '4hjoenwbwnuso',
+            'subscription_type'    => 1,
+            'm_payment_id'         => '5',
+            'amount'               => '5.00',
+            'recurring_amount'     => '5',
+            'billing_date'         => '2023-01-01',
+            'frequency'            => 3,
+            'cycles'               => 0,
+            'custom_str1'          => rtrim(base64_encode('Some Test String'), '='),
+            'custom_int1'          => 1,
+            'custom_int2'          => 1,
+            'custom_str2'          => rtrim(base64_encode('Another Test String'), '='),
+            'item_name'            => 'Test',
+            'name_last'            => 'Test',
+            'name_first'           => 'Test',
+            'email_address'        => 'test@test.com',
+            'confirmation_address' => 'test@test.test',
+            'email_confirmation'   => 1,
+            'return_url'           => 'https://test.com/billing/success',
+            'cancel_url'           => 'https://test.com/billing/cancel',
+            'notify_url'           => 'https://test.com/payfast/webhook'
         );
+
         // signature should generated using the correct order
-        $signature =  Auth::generateSignature($this->shuffleArrayPreserveKeys($data), $passPhrase = 'test');
-        $this->assertTrue("539985d720d80597ed4a1a994871f388" === $signature);
+        $signature =  Auth::generateSignature($this->shuffleArrayPreserveKeys($data), $passPhrase = 'payfastsandbox');
+        $this->assertTrue("3441682c5d8a65486f5b7cc8ce41d146" === $signature);
     }
 }
 ?>

--- a/tests/unit/AuthTest.php
+++ b/tests/unit/AuthTest.php
@@ -1,0 +1,37 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use PayFast\Auth;
+
+class AuthTest extends TestCase
+{
+    private function shuffleArrayPreserveKeys($array)
+    {
+        $keys = array_keys($array);
+        shuffle($keys);
+        print_r($data);
+        $new = [];
+        foreach ($keys as $key)
+        {
+            $new[$key] = $array[$key];
+        }
+        return $new;
+    }
+    public function testGenerateSignatureOrdering()
+    {
+        $data = array(
+            'email_address' => 'test@test.com',
+            'merchant_key' => '46f0cd694581a',
+            'notify_url' => 'http://www.example.com/notify_url',
+            'name_first' => 'First',
+            'name_last' => 'Last',
+            'cancel_url' => 'http://www.example.com/cancel_url',
+            'return_url' => 'http://www.example.com/return_url',
+            'merchant_id' => '10000100',
+        );
+        // signature should generated using the correct order
+        $signature =  Auth::generateSignature($this->shuffleArrayPreserveKeys($data), $passPhrase = 'test');
+        $this->assertTrue("539985d720d80597ed4a1a994871f388" === $signature);
+    }
+}
+?>
+

--- a/tests/unit/AuthTest.php
+++ b/tests/unit/AuthTest.php
@@ -8,7 +8,6 @@ class AuthTest extends TestCase
     {
         $keys = array_keys($array);
         shuffle($keys);
-        print_r($data);
         $new = [];
         foreach ($keys as $key)
         {


### PR DESCRIPTION
Added a unit test for signature generation. This relates to https://github.com/PayFast/payfast-php-sdk/commit/897e88dabc99283e891d6f8dbad25ccca7a787b9#r94749980.

The data in the unit tests are irrelevant, but the signature must be valid, e.g. for `generateSignature($data, $pass)`, the order of the `$data` from the user side should not matter - it should always generate the same hash, using the order of internal `$fields` in `generateSignature(...)`.